### PR TITLE
Ignition s1 fix

### DIFF
--- a/urdf/rplidar_s1.gazebo.xacro
+++ b/urdf/rplidar_s1.gazebo.xacro
@@ -34,7 +34,9 @@
           <mesh filename="file://$(find ros_components_description)/meshes/rplidar_s1.stl" scale="0.0001 0.0001 0.0001" />
         </geometry>
         <origin xyz="0.0 0.0 ${0.051/2.0}" rpy="0.0 0.0 -${pi/2.0}" />
-        <material name="DarkGrey" />
+        <material name="DarkGrey">
+          <color rgba="0.05 0.05 0.05 1.0" />
+        </material>
       </visual>
 
       <collision>

--- a/urdf/rplidar_s1.gazebo.xacro
+++ b/urdf/rplidar_s1.gazebo.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:macro name="rplidar_s1"
-               params="parent_link xyz rpy
+    params="parent_link xyz rpy
                        use_gpu:=false
                        tf_prefix:=None
                        topic:=scan
@@ -33,15 +33,15 @@
         <geometry>
           <mesh filename="file://$(find ros_components_description)/meshes/rplidar_s1.stl" scale="0.0001 0.0001 0.0001" />
         </geometry>
-        <origin xyz="0.0 0.0 ${0.051/2.0}" rpy="0.0 0.0 -${pi/2.0}"/>
-        <material name="DarkGrey"/>
+        <origin xyz="0.0 0.0 ${0.051/2.0}" rpy="0.0 0.0 -${pi/2.0}" />
+        <material name="DarkGrey" />
       </visual>
 
       <collision>
         <geometry>
           <cylinder radius="${0.0555/2.0}" length="0.051" />
         </geometry>
-        <origin xyz="0.0 0.0 ${0.051/2.0}" rpy="0.0 0.0 0.0"/>
+        <origin xyz="0.0 0.0 ${0.051/2.0}" rpy="0.0 0.0 0.0" />
       </collision>
 
       <inertial>
@@ -60,7 +60,12 @@
 
     <gazebo reference="${tf_prefix_ext}${frame_id}">
       <sensor type="${ray_type}" name="${tf_prefix_ext}rplidar_s1_sensor">
-        <visualize>false</visualize>
+        <topic>/scan</topic>
+
+        <frame_id>${tf_prefix_ext}${frame_id}</frame_id>
+        <ignition_frame_id>${tf_prefix_ext}${frame_id}</ignition_frame_id>
+
+        <update_rate>10.0</update_rate>
         <ray>
           <scan>
             <horizontal>
@@ -71,20 +76,27 @@
             </horizontal>
           </scan>
           <range>
-            <min>0.2</min>
+            <min>0.04</min>
             <max>40.0</max>
             <resolution>0.03</resolution>
           </range>
-
           <noise>
             <type>gaussian</type>
             <mean>0.0</mean>
             <stddev>0.001</stddev>
           </noise>
         </ray>
-        
-        <update_rate>10.0</update_rate>
-
+        <always_on>1</always_on>
+        <visualize>true</visualize>
+      </sensor>
+    </gazebo>
+    <gazebo>
+      <xacro:if value="${simulation_engine == 'ignition-gazebo'}">
+        <plugin filename="libignition-gazebo-sensors-system.so" name="ignition::gazebo::systems::Sensors">
+          <render_engine>ogre2</render_engine>
+        </plugin>
+      </xacro:if>
+      <xacro:if value="${simulation_engine == 'gazebo-classic'}">
         <plugin name="scan" filename="libgazebo_ros_ray_sensor.so">
           <ros>
             <namespace>/</namespace>
@@ -93,8 +105,8 @@
           <output_type>sensor_msgs/LaserScan</output_type>
           <frame_name>${tf_prefix_ext}${frame_id}</frame_name>
         </plugin>
-      </sensor>
-    </gazebo> 
+      </xacro:if>
+    </gazebo>
 
     <gazebo reference="${tf_prefix_ext}rplidar_s1_link">
       <material>Gazebo/DarkGrey</material>


### PR DESCRIPTION
Fixes simulation of rplidar S1 in ignition, adds DarkGrey material definition and changes min scan range (I couldn't find exact value in datasheet, one value was sub cm, which doesn't seem right, I think that 4cm should be ok).