### PR TITLE
Fix lidars and astra to work with gz-ign Fortress

### DIFF
--- a/urdf/orbbec_astra.urdf.xacro
+++ b/urdf/orbbec_astra.urdf.xacro
@@ -3,7 +3,7 @@
   <xacro:macro name="orbbec_astra"
                params="parent_link xyz rpy
                        tf_prefix:=None
-                       topic:=camera/depth/points
+                       topic:=camera
                        frame_id:=depth
                        simulation_engine:=gazebo-classic">
     
@@ -61,38 +61,72 @@
 
     <link name="${tf_prefix_ext}${frame_id}" />
 
-    <gazebo reference="${tf_prefix_ext}orbbec_astra_link">
-      <sensor type="depth" name="${tf_prefix_ext}orbbec_astra_camera">
-        <always_on>true</always_on>
-        <update_rate>20.0</update_rate>
+    <xacro:if value="${simulation_engine == 'ignition-gazebo'}">
+      <gazebo reference="${tf_prefix_ext}orbbec_astra_link">
+        <sensor type="rgbd_camera" name="${tf_prefix_ext}orbbec_astra_camera">
+          <always_on>true</always_on>
+          <update_rate>20.0</update_rate>
 
-        <camera name="${tf_prefix_ext}camera">
-          <horizontal_fov>${60.0/180.0*pi}</horizontal_fov>
-          <image>
-            <format>R8G8B8</format>
-            <width>640</width>
-            <height>480</height>
-          </image>
-        </camera>
+          <topic>${topic}</topic>
+          <!-- <frame_id>${tf_prefix_ext}${frame_id}</frame_id> -->
+          <optical_frame_id>${tf_prefix_ext}${frame_id}</optical_frame_id>
+          <ignition_frame_id>${tf_prefix_ext}${frame_id}</ignition_frame_id>
 
-        <plugin name="${tf_prefix_ext}orbbec_astra_camera" filename="libgazebo_ros_camera.so">
-          <ros>
-            <namespace>orbbec_astra_camera</namespace>
-            <remapping>custom_camera/image_raw:=rgb/image_raw</remapping>
-            <remapping>custom_camera/image_depth:=depth/image_raw</remapping>
-            <remapping>custom_camera/camera_info:=rgb/camera_info</remapping>
-            <remapping>custom_camera/camera_info_depth:=depth/camera_info</remapping>
-            <remapping>custom_camera/points:=depth/points</remapping>
-          </ros>
+          <camera name="${tf_prefix_ext}camera">
+            <horizontal_fov>${60.0/180.0*pi}</horizontal_fov>
+            <image>
+              <width>640</width>
+              <height>480</height>
+            </image>
 
-          <camera_name>${tf_prefix_ext}camera</camera_name>
-          <frame_name>${tf_prefix_ext}${frame_id}</frame_name>
-          <hack_baseline>0.07</hack_baseline>
-
-          <min_depth>0.6</min_depth>
-          <max_depth>8.0</max_depth>
+            <clip>
+              <near>0.6</near>
+              <far>8.0</far>
+            </clip>
+          </camera>
+        </sensor>
+      </gazebo>
+      <!-- <gazebo>
+        <plugin filename="libignition-gazebo-sensors-system.so" name="ignition::gazebo::systems::Sensors">
+          <render_engine>ogre2</render_engine>
         </plugin>
-      </sensor>
-    </gazebo> 
+      </gazebo>  -->
+    </xacro:if>
+
+    <xacro:if value="${simulation_engine == 'gazebo-classic'}">
+      <gazebo reference="${tf_prefix_ext}orbbec_astra_link">
+        <sensor type="depth" name="${tf_prefix_ext}orbbec_astra_camera">
+          <always_on>true</always_on>
+          <update_rate>20.0</update_rate>
+
+          <camera name="${tf_prefix_ext}camera">
+            <horizontal_fov>${60.0/180.0*pi}</horizontal_fov>
+            <image>
+              <format>R8G8B8</format>
+              <width>640</width>
+              <height>480</height>
+            </image>
+          </camera>
+
+          <plugin name="${tf_prefix_ext}orbbec_astra_camera" filename="libgazebo_ros_camera.so">
+            <ros>
+              <namespace>orbbec_astra_camera</namespace>
+              <remapping>custom_camera/image_raw:=rgb/image_raw</remapping>
+              <remapping>custom_camera/image_depth:=depth/image_raw</remapping>
+              <remapping>custom_camera/camera_info:=rgb/camera_info</remapping>
+              <remapping>custom_camera/camera_info_depth:=depth/camera_info</remapping>
+              <remapping>custom_camera/points:=depth/points</remapping>
+            </ros>
+
+            <camera_name>${tf_prefix_ext}camera</camera_name>
+            <frame_name>${tf_prefix_ext}${frame_id}</frame_name>
+            <hack_baseline>0.07</hack_baseline>
+
+            <min_depth>0.6</min_depth>
+            <max_depth>8.0</max_depth>
+          </plugin>
+        </sensor>
+      </gazebo> 
+    </xacro:if>
   </xacro:macro>
 </robot>

--- a/urdf/slamtec_rplidar_a2.urdf.xacro
+++ b/urdf/slamtec_rplidar_a2.urdf.xacro
@@ -27,8 +27,9 @@
         <xacro:property name="ray_type" value="ray" />
       </xacro:if>
       <xacro:if value="${simulation_engine == 'ignition-gazebo'}">
-        <!-- this is king of awkward, but it seems like cpu lidar does not work -->
-        <xacro:property name="ray_type" value="gpu_lidar" />
+        <!-- use_gpu has to be set to true, CPU lidar doesn't work in ignition -
+          https://github.com/gazebosim/gz-sensors/issues/26 -->
+        <xacro:property name="ray_type" value="lidar" />
       </xacro:if>
     </xacro:unless>
 

--- a/urdf/slamtec_rplidar_a2.urdf.xacro
+++ b/urdf/slamtec_rplidar_a2.urdf.xacro
@@ -15,10 +15,21 @@
                        simulation_engine:=gazebo-classic">
 
     <xacro:if value="${use_gpu}">
-      <xacro:property name="ray_type" value="gpu_ray" />
+      <xacro:if value="${simulation_engine == 'gazebo-classic'}">
+        <xacro:property name="ray_type" value="gpu_ray" />
+      </xacro:if>
+      <xacro:if value="${simulation_engine == 'ignition-gazebo'}">
+        <xacro:property name="ray_type" value="gpu_lidar" />
+      </xacro:if>
     </xacro:if>
     <xacro:unless value="${use_gpu}">
-      <xacro:property name="ray_type" value="ray" />
+      <xacro:if value="${simulation_engine == 'gazebo-classic'}">
+        <xacro:property name="ray_type" value="ray" />
+      </xacro:if>
+      <xacro:if value="${simulation_engine == 'ignition-gazebo'}">
+        <!-- this is king of awkward, but it seems like cpu lidar does not work -->
+        <xacro:property name="ray_type" value="gpu_lidar" />
+      </xacro:if>
     </xacro:unless>
 
     <xacro:if value="${tf_prefix == 'None'}">
@@ -90,7 +101,7 @@
       <gazebo reference="${tf_prefix_ext}${frame_id}">
         <sensor type="${ray_type}" name="${tf_prefix_ext}rplidar_a2_sensor">
           
-          <topic>scan</topic>
+          <topic>${topic}</topic>
           <frame_id>${tf_prefix_ext}${frame_id}</frame_id>
           <ignition_frame_id>${tf_prefix_ext}${frame_id}</ignition_frame_id>
 

--- a/urdf/slamtec_rplidar_a3.urdf.xacro
+++ b/urdf/slamtec_rplidar_a3.urdf.xacro
@@ -21,8 +21,9 @@
         <xacro:property name="ray_type" value="ray" />
       </xacro:if>
       <xacro:if value="${simulation_engine == 'ignition-gazebo'}">
-        <!-- this is king of awkward, but it seems like cpu lidar does not work -->
-        <xacro:property name="ray_type" value="gpu_lidar" />
+        <!-- use_gpu has to be set to true, CPU lidar doesn't work in ignition -
+          https://github.com/gazebosim/gz-sensors/issues/26 -->
+        <xacro:property name="ray_type" value="lidar" />
       </xacro:if>
     </xacro:unless>
 

--- a/urdf/slamtec_rplidar_a3.urdf.xacro
+++ b/urdf/slamtec_rplidar_a3.urdf.xacro
@@ -9,10 +9,21 @@
                        simulation_engine:=gazebo-classic">
 
     <xacro:if value="${use_gpu}">
-      <xacro:property name="ray_type" value="gpu_ray" />
+      <xacro:if value="${simulation_engine == 'gazebo-classic'}">
+        <xacro:property name="ray_type" value="gpu_ray" />
+      </xacro:if>
+      <xacro:if value="${simulation_engine == 'ignition-gazebo'}">
+        <xacro:property name="ray_type" value="gpu_lidar" />
+      </xacro:if>
     </xacro:if>
     <xacro:unless value="${use_gpu}">
-      <xacro:property name="ray_type" value="ray" />
+      <xacro:if value="${simulation_engine == 'gazebo-classic'}">
+        <xacro:property name="ray_type" value="ray" />
+      </xacro:if>
+      <xacro:if value="${simulation_engine == 'ignition-gazebo'}">
+        <!-- this is king of awkward, but it seems like cpu lidar does not work -->
+        <xacro:property name="ray_type" value="gpu_lidar" />
+      </xacro:if>
     </xacro:unless>
 
     <xacro:if value="${tf_prefix == 'None'}">
@@ -65,7 +76,7 @@
       <gazebo reference="${tf_prefix_ext}${frame_id}">
         <sensor type="${ray_type}" name="${tf_prefix_ext}rplidar_a3_sensor">
           
-          <topic>scan</topic>
+          <topic>${topic}</topic>
           <frame_id>${tf_prefix_ext}${frame_id}</frame_id>
           <ignition_frame_id>${tf_prefix_ext}${frame_id}</ignition_frame_id>
 

--- a/urdf/slamtec_rplidar_s1.urdf.xacro
+++ b/urdf/slamtec_rplidar_s1.urdf.xacro
@@ -9,10 +9,21 @@
                        simulation_engine:=gazebo-classic">
 
     <xacro:if value="${use_gpu}">
-      <xacro:property name="ray_type" value="gpu_ray" />
+      <xacro:if value="${simulation_engine == 'gazebo-classic'}">
+        <xacro:property name="ray_type" value="gpu_ray" />
+      </xacro:if>
+      <xacro:if value="${simulation_engine == 'ignition-gazebo'}">
+        <xacro:property name="ray_type" value="gpu_lidar" />
+      </xacro:if>
     </xacro:if>
     <xacro:unless value="${use_gpu}">
-      <xacro:property name="ray_type" value="ray" />
+      <xacro:if value="${simulation_engine == 'gazebo-classic'}">
+        <xacro:property name="ray_type" value="ray" />
+      </xacro:if>
+      <xacro:if value="${simulation_engine == 'ignition-gazebo'}">
+        <!-- this is king of awkward, but it seems like cpu lidar does not work -->
+        <xacro:property name="ray_type" value="gpu_lidar" />
+      </xacro:if>
     </xacro:unless>
 
     <xacro:if value="${tf_prefix == 'None'}">
@@ -73,7 +84,7 @@
       <gazebo reference="${tf_prefix_ext}${frame_id}">
         <sensor type="${ray_type}" name="${tf_prefix_ext}rplidar_s1_sensor">
           
-          <topic>scan</topic>
+          <topic>${topic}</topic>
           <frame_id>${tf_prefix_ext}${frame_id}</frame_id>
           <ignition_frame_id>${tf_prefix_ext}${frame_id}</ignition_frame_id>
 
@@ -81,7 +92,7 @@
           <ray>
             <scan>
               <horizontal>
-                <samples>9200</samples>
+                <samples>920</samples>
                 <resolution>1</resolution>
                 <min_angle>-${pi}</min_angle>
                 <max_angle>${pi}</max_angle>
@@ -103,10 +114,10 @@
         </sensor>
       </gazebo>
       <gazebo>
-          <plugin filename="libignition-gazebo-sensors-system.so" name="ignition::gazebo::systems::Sensors">
-            <render_engine>ogre2</render_engine>
-          </plugin>
-        </gazebo>
+        <plugin filename="libignition-gazebo-sensors-system.so" name="ignition::gazebo::systems::Sensors">
+          <render_engine>ogre2</render_engine>
+        </plugin>
+      </gazebo>
     </xacro:if>
 
     <xacro:if value="${simulation_engine == 'gazebo-classic'}">

--- a/urdf/slamtec_rplidar_s1.urdf.xacro
+++ b/urdf/slamtec_rplidar_s1.urdf.xacro
@@ -21,8 +21,9 @@
         <xacro:property name="ray_type" value="ray" />
       </xacro:if>
       <xacro:if value="${simulation_engine == 'ignition-gazebo'}">
-        <!-- this is king of awkward, but it seems like cpu lidar does not work -->
-        <xacro:property name="ray_type" value="gpu_lidar" />
+        <!-- use_gpu has to be set to true, CPU lidar doesn't work in ignition -
+          https://github.com/gazebosim/gz-sensors/issues/26 -->
+        <xacro:property name="ray_type" value="lidar" />
       </xacro:if>
     </xacro:unless>
 


### PR DESCRIPTION
Adds GZ-Ign Fortress support for RPLidars and Orbbec Astra. RPlidars work with GPU. Astra does not yet support point cloud due to issues related to the implementation of handling frame id for depth camera in ign-gz.