### PR TITLE
ROS 2 removed spaces | fixed build instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@ URDF models of sensors and other components offered alongside with Husarion robo
 
 First build the package by running:
 ``` bash
-git clone -b ros2 https://github.com/husarion/ros_components_description.git
+# create workspace folder and clone ros_components_description
+mkdir -p ros2_ws/src
+cd ros2_ws
+git clone https://github.com/husarion/ros_components_description.git src/ros_components_description
+
 # in case the package will be used within simulation
 export HUSARION_ROS_BUILD_TYPE=simulation
 
@@ -38,7 +42,7 @@ A list of parameters can be found here:
 - `parent_link` [*string*, default: **None**] parent link to which sensor should be attached.
 - `xyz` [*float list*, default: **None**] 3 float values defining translation between base of a sensor and parent link. Values in **m**.
 - `rpy` [*float list*, default: **None**] 3 float values define rotation between parent link and base of a sensor. Values in **rad**.
-- `tf_prefix` [*string*, optional] tf prefix applied before all links created by sensor. If defined, applies `<tf_prefix>_<sensor_name>`. If not defined, leaves `<sensor_name>` intact. Applies also to `frame_id` parameter. 
+- `tf_prefix` [*string*, optional] tf prefix applied before all links created by sensor. If defined, applies `<tf_prefix>_<sensor_name>`. If not defined, leaves `<sensor_name>` intact. Applies also to `frame_id` parameter.
 - `topic` [*string*, default: **same as default of manufacturer**] name of topic at which simulated sensor will publish data.
 - `frame_id` [*string*, default: **same as default of manufacturer**] name of final tf to which sensor will be attached. Should match one from message published by sensor.
 - `use_gpu` [*bool*, default: **false**] enable GPU acceleration for sensor. Available only if sensor can be accelerated.

--- a/package.xml
+++ b/package.xml
@@ -16,7 +16,7 @@
   <url type="bugtracker">https://github.com/husarion/ros_components_description/issues</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  
+
   <depend>robot_state_publisher</depend>
   <depend>urdf</depend>
   <depend>xacro</depend>

--- a/urdf/intel_realsense_d435.urdf.xacro
+++ b/urdf/intel_realsense_d435.urdf.xacro
@@ -22,7 +22,7 @@
     params="parent_link xyz rpy
             name:=camera
             topic:=camera
-            use_nominal_extrinsics:=false 
+            use_nominal_extrinsics:=false
             simulation_engine:=ignition-gazebo">
 
     <!-- The following values are approximate, and the camera node

--- a/urdf/orbbec_astra.urdf.xacro
+++ b/urdf/orbbec_astra.urdf.xacro
@@ -6,7 +6,7 @@
                        topic:=camera
                        frame_id:=depth
                        simulation_engine:=gazebo-classic">
-    
+
     <xacro:if value="${tf_prefix == 'None'}">
       <xacro:property name="tf_prefix_ext" value="" />
     </xacro:if>
@@ -126,7 +126,7 @@
             <max_depth>8.0</max_depth>
           </plugin>
         </sensor>
-      </gazebo> 
+      </gazebo>
     </xacro:if>
   </xacro:macro>
 </robot>

--- a/urdf/ouster_os1_32.urdf.xacro
+++ b/urdf/ouster_os1_32.urdf.xacro
@@ -92,7 +92,7 @@
             <stddev>0.0008</stddev>
           </noise>
         </ray>
-        
+
         <update_rate>20.0</update_rate>
 
         <plugin name="${tf_prefix_ext}ouster_os1_32_${ray_type}" filename="libgazebo_ros_ray_sensor.so">
@@ -104,6 +104,6 @@
           <frame_name>${tf_prefix_ext}${frame_id}</frame_name>
         </plugin>
       </sensor>
-    </gazebo> 
+    </gazebo>
   </xacro:macro>
 </robot>

--- a/urdf/slamtec_rplidar_a2.urdf.xacro
+++ b/urdf/slamtec_rplidar_a2.urdf.xacro
@@ -89,7 +89,7 @@
                                                      izz="0.00013718" />
       </inertial>
     </link>
-    
+
     <joint name="${tf_prefix_ext}slamtec_rplidar_a2_to_${tf_prefix_ext}${frame_id.rstrip('_link')}_joint" type="fixed">
       <origin xyz="0.0 0.0 0.031" rpy="0.0 0.0 ${pi}" />
       <parent link="${tf_prefix_ext}slamtec_rplidar_a2_link" />
@@ -101,7 +101,7 @@
     <xacro:if value="${simulation_engine == 'ignition-gazebo'}">
       <gazebo reference="${tf_prefix_ext}${frame_id}">
         <sensor type="${ray_type}" name="${tf_prefix_ext}rplidar_a2_sensor">
-          
+
           <topic>${topic}</topic>
           <frame_id>${tf_prefix_ext}${frame_id}</frame_id>
           <ignition_frame_id>${tf_prefix_ext}${frame_id}</ignition_frame_id>
@@ -162,9 +162,9 @@
               <stddev>0.001</stddev>
             </noise>
           </ray>
-          
+
           <update_rate>10.0</update_rate>
-          
+
           <plugin name="scan" filename="libgazebo_ros_ray_sensor.so">
             <ros>
               <namespace></namespace>
@@ -174,7 +174,7 @@
             <frame_name>${tf_prefix_ext}${frame_id}</frame_name>
           </plugin>
         </sensor>
-      </gazebo> 
+      </gazebo>
     </xacro:if>
   </xacro:macro>
 </robot>

--- a/urdf/slamtec_rplidar_a3.urdf.xacro
+++ b/urdf/slamtec_rplidar_a3.urdf.xacro
@@ -64,7 +64,7 @@
                                                      izz="0.00013718" />
       </inertial>
     </link>
-    
+
     <joint name="${tf_prefix_ext}slamtec_rplidar_a3_to_${tf_prefix_ext}${frame_id.rstrip('_link')}_joint" type="fixed">
       <origin xyz="0.0 0.0 0.031" rpy="0.0 0.0 ${pi}" />
       <parent link="${tf_prefix_ext}slamtec_rplidar_a3_link" />
@@ -76,7 +76,7 @@
     <xacro:if value="${simulation_engine == 'ignition-gazebo'}">
       <gazebo reference="${tf_prefix_ext}${frame_id}">
         <sensor type="${ray_type}" name="${tf_prefix_ext}rplidar_a3_sensor">
-          
+
           <topic>${topic}</topic>
           <frame_id>${tf_prefix_ext}${frame_id}</frame_id>
           <ignition_frame_id>${tf_prefix_ext}${frame_id}</ignition_frame_id>
@@ -139,9 +139,9 @@
               <stddev>0.001</stddev>
             </noise>
           </ray>
-          
+
           <update_rate>10.0</update_rate>
-          
+
           <plugin name="scan" filename="libgazebo_ros_ray_sensor.so">
             <ros>
               <namespace></namespace>
@@ -151,7 +151,7 @@
             <frame_name>${tf_prefix_ext}${frame_id}</frame_name>
           </plugin>
         </sensor>
-      </gazebo> 
+      </gazebo>
     </xacro:if>
   </xacro:macro>
 </robot>

--- a/urdf/slamtec_rplidar_s1.urdf.xacro
+++ b/urdf/slamtec_rplidar_s1.urdf.xacro
@@ -55,7 +55,7 @@
           <cylinder radius="${0.0555/2.0}" length="0.051" />
         </geometry>
       </collision>
-      
+
       <!-- base collision -->
       <collision>
         <origin xyz="0.0 0.0 ${0.0195/2.0}" rpy="0.0 0.0 0.0" />
@@ -72,7 +72,7 @@
                                                      izz="0.000053884" />
       </inertial>
     </link>
-    
+
     <joint name="${tf_prefix_ext}slamtec_rplidar_s1_to_${tf_prefix_ext}${frame_id.rstrip('_link')}_joint" type="fixed">
       <origin xyz="0.0 0.0 0.04" rpy="0.0 0.0 ${pi}" />
       <parent link="${tf_prefix_ext}slamtec_rplidar_s1_link" />
@@ -84,7 +84,7 @@
     <xacro:if value="${simulation_engine == 'ignition-gazebo'}">
       <gazebo reference="${tf_prefix_ext}${frame_id}">
         <sensor type="${ray_type}" name="${tf_prefix_ext}rplidar_s1_sensor">
-          
+
           <topic>${topic}</topic>
           <frame_id>${tf_prefix_ext}${frame_id}</frame_id>
           <ignition_frame_id>${tf_prefix_ext}${frame_id}</ignition_frame_id>
@@ -145,9 +145,9 @@
               <stddev>0.001</stddev>
             </noise>
           </ray>
-          
+
           <update_rate>10.0</update_rate>
-          
+
           <plugin name="scan" filename="libgazebo_ros_ray_sensor.so">
             <ros>
               <namespace></namespace>
@@ -157,7 +157,7 @@
             <frame_name>${tf_prefix_ext}${frame_id}</frame_name>
           </plugin>
         </sensor>
-      </gazebo> 
+      </gazebo>
     </xacro:if>
   </xacro:macro>
 </robot>

--- a/urdf/velodyne_puck.urdf.xacro
+++ b/urdf/velodyne_puck.urdf.xacro
@@ -117,7 +117,7 @@
             <frame_name>${tf_prefix_ext}${frame_id}</frame_name>
           </plugin>
         </xacro:if>
-        
+
       </sensor>
     </gazebo>
   </xacro:macro>


### PR DESCRIPTION
According to this issue #23 the instruction is not correct. I added creating workspace commands.