### PR TITLE
Unify astra description with real camera

### DIFF
--- a/urdf/orbbec_astra.urdf.xacro
+++ b/urdf/orbbec_astra.urdf.xacro
@@ -3,9 +3,9 @@
   <xacro:macro name="orbbec_astra"
                params="parent_link xyz rpy
                        tf_prefix:=None
-                       topic:=camera
-                       frame_id:=depth
-                       simulation_engine:=gazebo-classic">
+                       camera_name:=camera
+                       simulation_engine:=gazebo-classic
+                       use_sim:=false">
 
     <xacro:if value="${tf_prefix == 'None'}">
       <xacro:property name="tf_prefix_ext" value="" />
@@ -14,13 +14,13 @@
       <xacro:property name="tf_prefix_ext" value="${tf_prefix}_" />
     </xacro:unless>
 
-    <joint name="${parent_link.rstrip('_link')}_to_${tf_prefix_ext}orbbec_astra_joint" type="fixed">
+    <joint name="${parent_link.rstrip('_link')}_to_${tf_prefix_ext}${camera_name}_orbbec_astra_joint" type="fixed">
       <origin xyz="${xyz}" rpy="${rpy}" />
       <parent link="${parent_link}" />
-      <child link="${tf_prefix_ext}orbbec_astra_link" />
+      <child link="${tf_prefix_ext}${camera_name}_orbbec_astra_link" />
     </joint>
 
-    <link name="${tf_prefix_ext}orbbec_astra_link">
+    <link name="${tf_prefix_ext}${camera_name}_orbbec_astra_link">
       <visual>
         <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
         <geometry>
@@ -53,24 +53,51 @@
       </inertial>
     </link>
 
-    <joint name="${tf_prefix_ext}orbbec_astra_to_${tf_prefix_ext}${frame_id.rstrip('_link')}_joint" type="fixed">
-      <origin xyz="0.01 0.0 0.035" rpy="${-pi/2.0} 0.0 ${-pi/2.0}" />
-      <parent link="${tf_prefix_ext}orbbec_astra_link" />
-      <child link="${tf_prefix_ext}${frame_id}" />
-    </joint>
+    <xacro:if value="$(arg use_sim)">
+      <joint name="${parent_link.rstrip('_link')}_to_${tf_prefix_ext}${camera_name}_color_joint" type="fixed">
+        <origin xyz="-0.002 0.0125 0.03325" rpy="-0.003 0.0 -0.003" />
+        <parent link="${parent_link}" />
+        <child link="${tf_prefix_ext}${camera_name}_color_frame" />
+      </joint>
 
-    <link name="${tf_prefix_ext}${frame_id}" />
+      <link name="${tf_prefix_ext}${camera_name}_depth_frame" />
+
+      <joint name="${parent_link.rstrip('_link')}_to_${tf_prefix_ext}${camera_name}_depth_joint" type="fixed">
+        <origin xyz="0.0 0.0 0.03325" rpy="0.0 0.0 0.0" />
+        <parent link="${parent_link}" />
+        <child link="${tf_prefix_ext}${camera_name}_depth_frame" />
+      </joint>
+
+      <link name="${tf_prefix_ext}${camera_name}_color_frame" />
+
+      <joint name="${tf_prefix_ext}${camera_name}_color_to_${tf_prefix_ext}${camera_name}_color_optical_joint" type="fixed">
+        <origin xyz="0.0 0.0 0.0" rpy="${-pi/2} 0.0 ${-pi/2}" />
+        <parent link="${tf_prefix_ext}${camera_name}_color_frame" />
+        <child link="${tf_prefix_ext}${camera_name}_color_optical_frame" />
+      </joint>
+
+      <link name="${tf_prefix_ext}${camera_name}_depth_optical_frame" />
+
+      <joint name="${tf_prefix_ext}${camera_name}_depth_to_${tf_prefix_ext}${camera_name}_depth_optical_joint" type="fixed">
+        <origin xyz="0.1 0.0 0.0" rpy="${-pi/2} 0.0 ${-pi/2}" />
+        <parent link="${tf_prefix_ext}${camera_name}_depth_frame" />
+        <child link="${tf_prefix_ext}${camera_name}_depth_optical_frame" />
+      </joint>
+
+      <link name="${tf_prefix_ext}${camera_name}_color_optical_frame" />
+
+    </xacro:if>
 
     <xacro:if value="${simulation_engine == 'ignition-gazebo'}">
-      <gazebo reference="${tf_prefix_ext}orbbec_astra_link">
-        <sensor type="rgbd_camera" name="${tf_prefix_ext}orbbec_astra_camera">
+      <gazebo reference="${tf_prefix_ext}${camera_name}_orbbec_astra_link">
+        <sensor type="rgbd_camera" name="${tf_prefix_ext}${camera_name}_orbbec_astra_camera">
           <always_on>true</always_on>
           <update_rate>20.0</update_rate>
 
-          <topic>${topic}</topic>
-          <!-- <frame_id>${tf_prefix_ext}${frame_id}</frame_id> -->
-          <optical_frame_id>${tf_prefix_ext}${frame_id}</optical_frame_id>
-          <ignition_frame_id>${tf_prefix_ext}${frame_id}</ignition_frame_id>
+          <topic>${camera_name}</topic>
+          <!-- It is not possible to split the frame of the color and the depth stream.
+               The frame of color stream should be ${tf_prefix_ext}${camera_name}_color_optical_frame -->
+          <ignition_frame_id>${tf_prefix_ext}${camera_name}_depth_optical_frame</ignition_frame_id>
 
           <camera name="${tf_prefix_ext}camera">
             <horizontal_fov>${60.0/180.0*pi}</horizontal_fov>


### PR DESCRIPTION
In the ignition simulation and real astra the topics didn't coincide.
The frames weren't in the lenses.
![image](https://github.com/husarion/ros_components_description/assets/109142865/c13e42af-117c-4d40-984e-ea33e8c8921b)

There are still 3 issues:
- [ ] The frame of color stream should be `camera_color_optical_frame` not `camera_depth_optical_frame`. The 
- [ ] The frame of pointcloud2 should be `camera_depth_optical_frame` but there is an issue with `ign-sensors6`.  See https://github.com/gazebosim/gz-sensors/issues/239.
- [ ] The links are included only in case `use_sim` due to bugs in `ros_astra_camera`.

![image](https://github.com/husarion/ros_components_description/assets/109142865/3e692bac-d0b3-412d-b766-c986a66fa01b)
The pointcloud2 frame issue is solved with proposed workaround solution:
```python3
depth_cam_frame_fixer = Node(package='tf2_ros',
                            executable='static_transform_publisher',
                            name='depth_to_camera',
                            output='log',
                            arguments=['0.0', '0.0', '0.0', '1.57', '-1.57', '0.0',
                                        'camera_depth_optical_frame', 'rosbot/base_link/camera_orbbec_astra_camera'
                                        ])
```

TF tree:
![Screenshot from 2023-07-11 09-49-13](https://github.com/husarion/ros_components_description/assets/109142865/51979d36-6b39-4829-b872-4bd7713e6aa6)
